### PR TITLE
fix: resetting the module cache is no longer a problem

### DIFF
--- a/index.js
+++ b/index.js
@@ -43,7 +43,9 @@ class User {
     }
 }
 
-const scenarios = new Map();
+const scenarios = global.scenarios || new Map();
+
+global.scenarios = scenarios;
 
 class Scenario {
     constructor (description) {


### PR DESCRIPTION
This PR fixes the issue indicated here: https://stackoverflow.com/questions/69656944/failed-to-run-tests-with-more-than-3-users-with-testcafe
The problem was caused by resetting the hash of modules called from tests launched by the TestCafe runner, starting from version 1.15.3.
This fix is bad since it uses a global variable, but I haven't found a better solution.
Perhaps in the future TestCafe will allow you to disable the option to clear the cache. Then this fix will cease to be necessary.